### PR TITLE
Align flake8 max line length with Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,4 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: ["flake8-bugbear"]
+        args: ["--max-line-length=100"]


### PR DESCRIPTION
## Summary
- configure the flake8 pre-commit hook to use a 100 character line length

## Testing
- pre-commit run --all-files *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2e4c923483209b06be1148f76044